### PR TITLE
FF ONLY Towards 1.0.0 again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ scala:
 jdk:
   - oraclejdk8
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION scalajs-stubs/publishLocal
+  - sbt ++$TRAVIS_SCALA_VERSION scalajs-stubs/publishLocal scalajs-stubs/mimaReportBinaryIssues
 cache:
   directories:
     - $HOME/.ivy2/cache

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
+val previousVersion = "1.0.0-RC1"
+
 inThisBuild(Def.settings(
-  version := "1.0.0-RC1",
+  version := "1.0.0-SNAPSHOT",
   organization := "org.scala-js",
 
   crossScalaVersions := Seq("2.12.6", "2.10.7", "2.11.12", "2.13.0-M4", "2.13.0-M5"),
@@ -17,6 +19,9 @@ inThisBuild(Def.settings(
 
 lazy val `scalajs-stubs`: Project = project.in(file("."))
   .settings(
+    mimaPreviousArtifacts +=
+      organization.value %% moduleName.value % previousVersion,
+
     publishMavenStyle := true,
     publishTo := {
       val nexus = "https://oss.sonatype.org/"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.2.0")


### PR DESCRIPTION
This includes the setup of MiMa wrt. 1.0.0-RC1. It is not strictly necessary at this point, but it does not hurt. This API really should not break anymore.