### PR TITLE
update scala versions and add support for scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ inThisBuild(Def.settings(
   version := "1.0.1-SNAPSHOT",
   organization := "org.scala-js",
 
-  crossScalaVersions := Seq("2.12.8", "2.10.7", "2.11.12", "2.13.0"),
+  crossScalaVersions := Seq("2.12.14", "2.10.7", "2.11.12", "2.13.6", "3.0.0"),
   scalaVersion := crossScalaVersions.value.head,
   scalacOptions ++= Seq("-deprecation", "-feature", "-Xfatal-warnings"),
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.5.4


### PR DESCRIPTION
I tried this locally in the `shared` folder of a crossproject setup using scala 3, based upon this PR:

```scala
@js.native
trait StateModel extends js.Object {

}
```
but I still get this compile error:

```s
[error] -- [E008] Not Found Error: 
ExampleData.scala:42:4 -----------------------------------
[error] 42 |@js.native
[error]    | ^^^^^^^^^
[error]    | type native is not a member of scala.scalajs.js
[error] -- [E008] Not Found Error: 

ExampleData.scala:43:28 ----------------------------------
[error] 43 |trait StateModel extends js.Object {
[error]    |                         ^^^^^^^^^
[error]    |                         type Object is not a member of scala.scalajs.js
[error] two errors found
[error] two errors found
[error] (webJVM / Compile / compileIncremental) Compilation failed
```

Is there a way to get this work, or maybe I misunderstand something.